### PR TITLE
Use importlib instead of os for registering schemas

### DIFF
--- a/invenio_search/ext.py
+++ b/invenio_search/ext.py
@@ -186,7 +186,9 @@ class _SearchState(object):
                     and file_traversable.name.lower().endswith(".json")
                 ):
                     # split the path, get file name and remove the .json extension
-                    file_stem = file_traversable.name.split("/")[-1].strip(".json")
+                    file_stem = file_traversable.name.split("/")[-1].removesuffix(
+                        ".json"
+                    )
                     index_name = build_index_from_parts(*(parts + (file_stem,)))
                     yield MappingRec(
                         index_name=index_name,

--- a/invenio_search/ext.py
+++ b/invenio_search/ext.py
@@ -427,22 +427,22 @@ class _SearchState(object):
         # need to initialise Index class to use the .put_mapping API wrapper method
         index_ = dsl.Index(full_index_name, using=self.client)
 
-        with open(mapping_path, "r") as body:
-            mapping = json.load(body)["mappings"]
-            changes = list(dictdiffer.diff(old_mapping, mapping))
+        body = mapping_path.read_text()
+        mapping = json.loads(body)["mappings"]
+        changes = list(dictdiffer.diff(old_mapping, mapping))
 
-            # allow only additions to mappings (backwards compatibility is kept)
-            if not check or all([change[0] == "add" for change in changes]):
-                # raises 400 if the mapping cannot be updated
-                # (f.e. type changes or index needs to be closed)
-                index_.put_mapping(using=self.client, body=mapping)
-            else:
-                non_add_changes = [change for change in changes if change[0] != "add"]
-                raise NotAllowedMappingUpdate(
-                    "Only additions are allowed when updating mappings to keep backwards compatibility. "
-                    f"This mapping has {len(non_add_changes)} non addition changes.\n\n"
-                    f"Full list of changes: {changes}"
-                )
+        # allow only additions to mappings (backwards compatibility is kept)
+        if not check or all([change[0] == "add" for change in changes]):
+            # raises 400 if the mapping cannot be updated
+            # (f.e. type changes or index needs to be closed)
+            index_.put_mapping(using=self.client, body=mapping)
+        else:
+            non_add_changes = [change for change in changes if change[0] != "add"]
+            raise NotAllowedMappingUpdate(
+                "Only additions are allowed when updating mappings to keep backwards compatibility. "
+                f"This mapping has {len(non_add_changes)} non addition changes.\n\n"
+                f"Full list of changes: {changes}"
+            )
 
     def _replace_prefix(self, template_path, body, enforce_prefix):
         """Replace index prefix in template request body."""

--- a/invenio_search/ext.py
+++ b/invenio_search/ext.py
@@ -122,10 +122,16 @@ class _SearchState(object):
 
             # Make sure that the OpenSearch mappings are in the folder.
             # The fallback can be removed after transition to OpenSearch.
-            package_name = module.split(".")[0]
-            all_files = metadata_files(package_name)
             
-            subfolder_path = "/".join(module.split(".")) + "/" + subfolder
+            # Get package name from module, for example invenio_records_resources.records.mapping -> invenio_records_resources
+            package_name = module.split(".")[0]
+            all_files = metadata_files(package_name) # get all files in that package
+            
+            # construct a path with given module name and subfolder
+            # for example: invenio_records_resources.records.mapping -> invenio_records_resources/records/mapping -> invenio_records_resources/records/mapping/os-v2
+            subfolder_path = "/".join(module.split(".")) + "/" + subfolder 
+            
+            # check if there is a file that starts with that path name
             if not any(str(file_).startswith(subfolder_path) for file_ in all_files):
                 # fallback to ES folder with a warning if `os-vx` is not found
                 subfolder = "v7"
@@ -148,6 +154,9 @@ class _SearchState(object):
 
         :param alias: The alias.
         :param package_name: The package name.
+        
+        .. note:: Implementation then later assumes that mappings/templates have implemented read_text() function.
+        In the current version all paths to mappings/templates are instances of PackagePath.
         """
         package_name = self._get_mappings_module(package_name)
         
@@ -157,15 +166,23 @@ class _SearchState(object):
 
             data = aliases.get(root_name, {})
 
-            package_root = package_name.split(".")[0]            
+            # Get package name from module, for example invenio_records_resources.records.mapping -> invenio_records_resources 
+            package_root = package_name.split(".")[0]
+            # Get all files in that package            
             all_files = metadata_files(package_root)
             path = "/".join(package_name.split("."))
             
+            # Retrieve only necessary files
+            # For example:
+            # package_name = invenio_records_resources.records.mapping.groups 
+            # then path = invenio_records_resources/records/mapping/groups
+            # and relevant files will be only invenio_records_resources/records/mapping/groups/*  
             relevant_files = [
                 file for file in all_files
                 if (path + "/" + resource_name) in str(file)
             ]
             for file in relevant_files:
+                # filter out non json files
                 if not file.name.lower().endswith(".json"):
                     continue
                 
@@ -190,6 +207,7 @@ class _SearchState(object):
             parts = parts or tuple()
             resource_name = os.path.join(*parts) if parts else ""
             
+            # same logic as in register_mappings(...)
             package_root = module.split(".")[0]            
             all_files =metadata_files(package_root)
             path = "/".join(module.split("."))
@@ -306,6 +324,7 @@ class _SearchState(object):
         # make sure there is no index with the same name as the
         # alias name (i.e. the index name without the suffix).
        
+        # mapping path is now instance of PackagePath
         body =  mapping_path.read_text()
         final_index = build_index_name(
             index, prefix=prefix, suffix=suffix, app=self.app
@@ -430,6 +449,7 @@ class _SearchState(object):
         # need to initialise Index class to use the .put_mapping API wrapper method
         index_ = dsl.Index(full_index_name, using=self.client)
 
+        # mapping path is now instance of PackagePath
         body = mapping_path.read_text()
         mapping = json.loads(body)["mappings"]
         changes = list(dictdiffer.diff(old_mapping, mapping))
@@ -470,6 +490,8 @@ class _SearchState(object):
         fail if the template does not use the prefix
         """
         ignore = ignore or []
+        
+        # template is now instance of PackagePath
         body = template_file.read_text()
         replaced_body = self._replace_prefix(template_file, body, enforce_prefix)
         template_name = build_alias_name(template_name, app=self.app)

--- a/invenio_search/ext.py
+++ b/invenio_search/ext.py
@@ -170,7 +170,6 @@ class _SearchState(object):
 
     def _walk_dir(self, root, path, index_path=[], parts=()):
         """Walk through a directory and collect mappings."""
-
         root_name = build_index_from_parts(*parts)
 
         if path.is_dir():

--- a/invenio_search/ext.py
+++ b/invenio_search/ext.py
@@ -467,15 +467,14 @@ class _SearchState(object):
         fail if the template does not use the prefix
         """
         ignore = ignore or []
-        with open(template_file, "r") as fp:
-            body = fp.read()
-            replaced_body = self._replace_prefix(template_file, body, enforce_prefix)
-            template_name = build_alias_name(template_name, app=self.app)
-            return template_file, put_function(
-                name=template_name,
-                body=json.loads(replaced_body),
-                ignore=ignore,
-            )
+        body = template_file.read_text()
+        replaced_body = self._replace_prefix(template_file, body, enforce_prefix)
+        template_name = build_alias_name(template_name, app=self.app)
+        return template_file, put_function(
+            name=template_name,
+            body=json.loads(replaced_body),
+            ignore=ignore,
+        )
 
     def put_templates(self, ignore=None):
         """Yield tuple with registered template and response from client."""

--- a/invenio_search/ext.py
+++ b/invenio_search/ext.py
@@ -13,7 +13,6 @@
 import json
 import os
 import warnings
-from importlib.resources import files
 from importlib.metadata import files as metadata_files
 
 import dictdiffer
@@ -123,7 +122,11 @@ class _SearchState(object):
 
             # Make sure that the OpenSearch mappings are in the folder.
             # The fallback can be removed after transition to OpenSearch.
-            if not (files(module) / subfolder).is_dir():
+            package_name = module.split(".")[0]
+            all_files = metadata_files(package_name)
+            
+            subfolder_path = "/".join(module.split(".")) + "/" + subfolder
+            if not any(str(file_).startswith(subfolder_path) for file_ in all_files):
                 # fallback to ES folder with a warning if `os-vx` is not found
                 subfolder = "v7"
                 warnings.warn(

--- a/invenio_search/ext.py
+++ b/invenio_search/ext.py
@@ -163,9 +163,9 @@ class _SearchState(object):
             for p in mapping_rec.index_path:
                 data = data.setdefault(p, {})
 
-            assert mapping_rec.index_name not in data, (
-                f"Duplicate index: {mapping_rec.index_name}"
-            )
+            assert (
+                mapping_rec.index_name not in data
+            ), f"Duplicate index: {mapping_rec.index_name}"
             data[mapping_rec.index_name] = mapping_rec.file_traversable
 
     def _walk_dir(self, root, path, index_path=[], parts=()):

--- a/invenio_search/ext.py
+++ b/invenio_search/ext.py
@@ -163,9 +163,9 @@ class _SearchState(object):
             for p in mapping_rec.index_path:
                 data = data.setdefault(p, {})
 
-            assert mapping_rec.index_name not in data, (
-                f"Duplicate index: {mapping_rec.index_name}"
-            )
+            assert (
+                mapping_rec.index_name not in data
+            ), f"Duplicate index: {mapping_rec.index_name}"
             data[mapping_rec.index_name] = mapping_rec.file_traversable
 
     def _walk_dir(self, root, path, index_path=[]):

--- a/invenio_search/ext.py
+++ b/invenio_search/ext.py
@@ -122,15 +122,15 @@ class _SearchState(object):
 
             # Make sure that the OpenSearch mappings are in the folder.
             # The fallback can be removed after transition to OpenSearch.
-            
+
             # Get package name from module, for example invenio_records_resources.records.mapping -> invenio_records_resources
             package_name = module.split(".")[0]
-            all_files = metadata_files(package_name) # get all files in that package
-            
+            all_files = metadata_files(package_name)  # get all files in that package
+
             # construct a path with given module name and subfolder
             # for example: invenio_records_resources.records.mapping -> invenio_records_resources/records/mapping -> invenio_records_resources/records/mapping/os-v2
-            subfolder_path = "/".join(module.split(".")) + "/" + subfolder 
-            
+            subfolder_path = "/".join(module.split(".")) + "/" + subfolder
+
             # check if there is a file that starts with that path name
             if not any(str(file_).startswith(subfolder_path) for file_ in all_files):
                 # fallback to ES folder with a warning if `os-vx` is not found
@@ -154,43 +154,42 @@ class _SearchState(object):
 
         :param alias: The alias.
         :param package_name: The package name.
-        
+
         .. note:: Implementation then later assumes that mappings/templates have implemented read_text() function.
         In the current version all paths to mappings/templates are instances of PackagePath.
         """
         package_name = self._get_mappings_module(package_name)
-        
+
         def _walk_dir(aliases, *parts):
             root_name = build_index_from_parts(*parts)
             resource_name = os.path.join(*parts)
 
             data = aliases.get(root_name, {})
 
-            # Get package name from module, for example invenio_records_resources.records.mapping -> invenio_records_resources 
+            # Get package name from module, for example invenio_records_resources.records.mapping -> invenio_records_resources
             package_root = package_name.split(".")[0]
-            # Get all files in that package            
+            # Get all files in that package
             all_files = metadata_files(package_root)
             path = "/".join(package_name.split("."))
-            
+
             # Retrieve only necessary files
             # For example:
-            # package_name = invenio_records_resources.records.mapping.groups 
+            # package_name = invenio_records_resources.records.mapping.groups
             # then path = invenio_records_resources/records/mapping/groups
-            # and relevant files will be only invenio_records_resources/records/mapping/groups/*  
+            # and relevant files will be only invenio_records_resources/records/mapping/groups/*
             relevant_files = [
-                file for file in all_files
-                if (path + "/" + resource_name) in str(file)
+                file for file in all_files if (path + "/" + resource_name) in str(file)
             ]
             for file in relevant_files:
                 # filter out non json files
                 if not file.name.lower().endswith(".json"):
                     continue
-                
+
                 index_name = build_index_from_parts(*(parts + (file.stem,)))
                 assert index_name not in data, "Duplicate index"
                 data[index_name] = file
                 self.mappings[index_name] = file
-                
+
             aliases[root_name] = data
 
         _walk_dir(self.aliases, alias)
@@ -206,21 +205,20 @@ class _SearchState(object):
         def _walk_dir(*parts):
             parts = parts or tuple()
             resource_name = os.path.join(*parts) if parts else ""
-            
+
             # same logic as in register_mappings(...)
-            package_root = module.split(".")[0]            
-            all_files =metadata_files(package_root)
+            package_root = module.split(".")[0]
+            all_files = metadata_files(package_root)
             path = "/".join(module.split("."))
-            
+
             relevant_files = [
-                file for file in all_files
-                if (path + "/" + resource_name) in str(file)
+                file for file in all_files if (path + "/" + resource_name) in str(file)
             ]
-            
+
             for file in relevant_files:
                 if not file.name.lower().endswith(".json"):
                     continue
-                
+
                 template_name = build_index_from_parts(*(parts + (file.stem,)))
                 result[template_name] = file
 
@@ -323,9 +321,9 @@ class _SearchState(object):
         # index if the current instance is running without suffixes
         # make sure there is no index with the same name as the
         # alias name (i.e. the index name without the suffix).
-       
+
         # mapping path is now instance of PackagePath
-        body =  mapping_path.read_text()
+        body = mapping_path.read_text()
         final_index = build_index_name(
             index, prefix=prefix, suffix=suffix, app=self.app
         )
@@ -490,7 +488,7 @@ class _SearchState(object):
         fail if the template does not use the prefix
         """
         ignore = ignore or []
-        
+
         # template is now instance of PackagePath
         body = template_file.read_text()
         replaced_body = self._replace_prefix(template_file, body, enforce_prefix)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -28,6 +28,7 @@ def _get_version():
     version = "v{}" if SEARCH_DISTRIBUTION == ES else "os-v{}"
     return version.format(search_major_version)
 
+
 @pytest.mark.skip
 def test_init(app, template_entrypoints):
     """Run client initialization."""
@@ -107,6 +108,7 @@ def test_init(app, template_entrypoints):
 
     aliases = current_search_client.indices.get_alias()
     assert 0 == len(aliases)
+
 
 @pytest.mark.skip
 def test_list(app):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -29,7 +29,6 @@ def _get_version():
     return version.format(search_major_version)
 
 
-@pytest.mark.skip
 def test_init(app, template_entrypoints):
     """Run client initialization."""
     suffix = "-abc"
@@ -110,7 +109,6 @@ def test_init(app, template_entrypoints):
     assert 0 == len(aliases)
 
 
-@pytest.mark.skip
 def test_list(app):
     """Run listing of mappings."""
     suffix = "-abc"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -28,7 +28,7 @@ def _get_version():
     version = "v{}" if SEARCH_DISTRIBUTION == ES else "os-v{}"
     return version.format(search_major_version)
 
-
+@pytest.mark.skip
 def test_init(app, template_entrypoints):
     """Run client initialization."""
     suffix = "-abc"
@@ -108,7 +108,7 @@ def test_init(app, template_entrypoints):
     aliases = current_search_client.indices.get_alias()
     assert 0 == len(aliases)
 
-
+@pytest.mark.skip
 def test_list(app):
     """Run listing of mappings."""
     suffix = "-abc"

--- a/tests/test_invenio_search.py
+++ b/tests/test_invenio_search.py
@@ -98,6 +98,7 @@ def test_default_client(app):
     current_search_client.cluster.health(wait_for_status="yellow", request_timeout=1)
 
 
+@pytest.mark.skip
 def test_load_entry_point_group(template_entrypoints):
     """Test entry point loading."""
     app = Flask("testapp")
@@ -124,7 +125,7 @@ def test_load_entry_point_group(template_entrypoints):
     ):
         assert set(ext.templates.keys()) == {"record-view-{}".format(_get_version())}
 
-
+@pytest.mark.skip
 @pytest.mark.parametrize(
     ("aliases_config", "expected_aliases"),
     [
@@ -171,7 +172,7 @@ def test_whitelisted_aliases(app, aliases_config, expected_aliases):
 
     app.config["SEARCH_MAPPINGS"] = orig
 
-
+@pytest.mark.skip
 @pytest.mark.parametrize(
     ("suffix", "create_index", "create_alias", "expected"),
     [
@@ -235,7 +236,7 @@ def test_creating_alias_existing_index(
         if create_index:
             assert len(indices[create_index]["aliases"]) == 0
 
-
+@pytest.mark.skip
 @pytest.mark.parametrize(
     ("aliases_config", "prefix", "expected_aliases"),
     [
@@ -305,19 +306,19 @@ def _test_prefix_indices(app, prefix_value):
     # clean-up
     current_search_client.indices.delete("*", expand_wildcards="all")
 
-
+@pytest.mark.skip
 def test_indices_prefix_empty_value(app):
     """Test indices creation with prefix value empty string."""
     prefix_value = ""
     _test_prefix_indices(app, prefix_value)
 
-
+@pytest.mark.skip
 def test_indices_prefix_none_value(app):
     """Test indices creation with a prefix value None."""
     prefix_value = None
     _test_prefix_indices(app, prefix_value)
 
-
+@pytest.mark.skip
 def test_indices_prefix_some_value(app):
     """Test indices creation with a prefix value `myprefix-`."""
     prefix_value = "myprefix-"
@@ -388,6 +389,7 @@ def test_current_suffix(app):
     assert suffix == search.current_suffix
 
 
+@pytest.mark.skip()
 def test_not_dry_run_and_index_exists(app):
     """Test create_index and no dry run when index exists."""
     current_search_client.indices.delete("*", expand_wildcards="all")
@@ -397,7 +399,7 @@ def test_not_dry_run_and_index_exists(app):
     with pytest.raises(IndexAlreadyExistsError):
         list(search.create())
 
-
+@pytest.mark.skip()
 def test_create_selected_indexes(app):
     search = app.extensions["invenio-search"]
     current_search_client.indices.delete("*", expand_wildcards="all")
@@ -421,7 +423,7 @@ def test_create_selected_indexes(app):
     assert search.client.indices.exists("authors-authors-v1.0.0") is False
     assert search.client.indices.exists("records-authorities-authority-v1.0.0") is False
 
-
+@pytest.mark.skip()
 def test_delete_selected_indexes(app):
     search = app.extensions["invenio-search"]
     current_search_client.indices.delete("*", expand_wildcards="all")
@@ -436,7 +438,7 @@ def test_delete_selected_indexes(app):
         is True
     )
 
-
+@pytest.mark.skip()
 def test_create_when_indexes_already_exists_with_ignore_existing_true(app):
     search = app.extensions["invenio-search"]
     current_search_client.indices.delete("*", expand_wildcards="all")
@@ -449,7 +451,7 @@ def test_create_when_indexes_already_exists_with_ignore_existing_true(app):
         is True
     )
 
-
+@pytest.mark.skip()
 def test_update_mappings(app):
     """Test if mapping gets correctly updated."""
 

--- a/tests/test_invenio_search.py
+++ b/tests/test_invenio_search.py
@@ -231,6 +231,7 @@ def test_creating_alias_existing_index(
         with pytest.raises(Exception):
             results = list(current_search.create(ignore=None))
         indices = current_search_client.indices.get("*", expand_wildcards="all")
+        index_names = list(indices.keys())
         # filter out hidden indices like .plugins-ml-config
         index_names = [i for i in index_names if not i.startswith(".")]
         assert index_names == new_indexes

--- a/tests/test_invenio_search.py
+++ b/tests/test_invenio_search.py
@@ -363,19 +363,19 @@ def _test_prefix_templates(app, prefix_value, template_entrypoints):
         # clean-up
         current_search_client.indices.delete_template("*")
 
-
+@pytest.mark.skip
 def test_templates_prefix_empty_value(app, template_entrypoints):
     """Test templates creation with prefix value empty string."""
     prefix_value = ""
     _test_prefix_templates(app, prefix_value, template_entrypoints)
 
-
+@pytest.mark.skip
 def test_templates_prefix_none_value(app, template_entrypoints):
     """Test templates creation with a prefix value None."""
     prefix_value = None
     _test_prefix_templates(app, prefix_value, template_entrypoints)
 
-
+@pytest.mark.skip
 def test_templates_prefix_some_value(app, template_entrypoints):
     """Test templates creation with a prefix value `myprefix-`."""
     prefix_value = "myprefix-"

--- a/tests/test_invenio_search.py
+++ b/tests/test_invenio_search.py
@@ -10,6 +10,7 @@
 
 
 """Module tests."""
+
 import json
 from collections import defaultdict
 
@@ -55,7 +56,7 @@ def test_client_config():
     app.config["SEARCH_CLIENT_CONFIG"] = {"timeout": 30, "foo": "bar"}
 
     # instead of patching ES directly, we go via our transparency module
-    with patch(f"invenio_search.engine.SearchEngine.__init__") as mock_search_init:
+    with patch("invenio_search.engine.SearchEngine.__init__") as mock_search_init:
         mock_search_init.return_value = None
         ext = InvenioSearch(app)
         es_client = ext.client  # trigger client initialization
@@ -98,7 +99,6 @@ def test_default_client(app):
     current_search_client.cluster.health(wait_for_status="yellow", request_timeout=1)
 
 
-@pytest.mark.skip
 def test_load_entry_point_group(template_entrypoints):
     """Test entry point loading."""
     app = Flask("testapp")
@@ -126,7 +126,6 @@ def test_load_entry_point_group(template_entrypoints):
         assert set(ext.templates.keys()) == {"record-view-{}".format(_get_version())}
 
 
-@pytest.mark.skip
 @pytest.mark.parametrize(
     ("aliases_config", "expected_aliases"),
     [
@@ -174,7 +173,6 @@ def test_whitelisted_aliases(app, aliases_config, expected_aliases):
     app.config["SEARCH_MAPPINGS"] = orig
 
 
-@pytest.mark.skip
 @pytest.mark.parametrize(
     ("suffix", "create_index", "create_alias", "expected"),
     [
@@ -239,7 +237,6 @@ def test_creating_alias_existing_index(
             assert len(indices[create_index]["aliases"]) == 0
 
 
-@pytest.mark.skip
 @pytest.mark.parametrize(
     ("aliases_config", "prefix", "expected_aliases"),
     [
@@ -310,21 +307,18 @@ def _test_prefix_indices(app, prefix_value):
     current_search_client.indices.delete("*", expand_wildcards="all")
 
 
-@pytest.mark.skip
 def test_indices_prefix_empty_value(app):
     """Test indices creation with prefix value empty string."""
     prefix_value = ""
     _test_prefix_indices(app, prefix_value)
 
 
-@pytest.mark.skip
 def test_indices_prefix_none_value(app):
     """Test indices creation with a prefix value None."""
     prefix_value = None
     _test_prefix_indices(app, prefix_value)
 
 
-@pytest.mark.skip
 def test_indices_prefix_some_value(app):
     """Test indices creation with a prefix value `myprefix-`."""
     prefix_value = "myprefix-"
@@ -370,21 +364,18 @@ def _test_prefix_templates(app, prefix_value, template_entrypoints):
         current_search_client.indices.delete_template("*")
 
 
-@pytest.mark.skip
 def test_templates_prefix_empty_value(app, template_entrypoints):
     """Test templates creation with prefix value empty string."""
     prefix_value = ""
     _test_prefix_templates(app, prefix_value, template_entrypoints)
 
 
-@pytest.mark.skip
 def test_templates_prefix_none_value(app, template_entrypoints):
     """Test templates creation with a prefix value None."""
     prefix_value = None
     _test_prefix_templates(app, prefix_value, template_entrypoints)
 
 
-@pytest.mark.skip
 def test_templates_prefix_some_value(app, template_entrypoints):
     """Test templates creation with a prefix value `myprefix-`."""
     prefix_value = "myprefix-"
@@ -398,7 +389,6 @@ def test_current_suffix(app):
     assert suffix == search.current_suffix
 
 
-@pytest.mark.skip()
 def test_not_dry_run_and_index_exists(app):
     """Test create_index and no dry run when index exists."""
     current_search_client.indices.delete("*", expand_wildcards="all")
@@ -409,7 +399,6 @@ def test_not_dry_run_and_index_exists(app):
         list(search.create())
 
 
-@pytest.mark.skip()
 def test_create_selected_indexes(app):
     search = app.extensions["invenio-search"]
     current_search_client.indices.delete("*", expand_wildcards="all")
@@ -423,9 +412,7 @@ def test_create_selected_indexes(app):
     assert (
         search.client.indices.exists_alias(
             "records-bibliographic-bibliographic-v1.0.0",
-            "records,"
-            "records-bibliographic,"
-            "records-bibliographic-bibliographic-v1.0.0",
+            "records,records-bibliographic,records-bibliographic-bibliographic-v1.0.0",
         )
         is True
     )
@@ -434,7 +421,6 @@ def test_create_selected_indexes(app):
     assert search.client.indices.exists("records-authorities-authority-v1.0.0") is False
 
 
-@pytest.mark.skip()
 def test_delete_selected_indexes(app):
     search = app.extensions["invenio-search"]
     current_search_client.indices.delete("*", expand_wildcards="all")
@@ -450,7 +436,6 @@ def test_delete_selected_indexes(app):
     )
 
 
-@pytest.mark.skip()
 def test_create_when_indexes_already_exists_with_ignore_existing_true(app):
     search = app.extensions["invenio-search"]
     current_search_client.indices.delete("*", expand_wildcards="all")
@@ -464,7 +449,6 @@ def test_create_when_indexes_already_exists_with_ignore_existing_true(app):
     )
 
 
-@pytest.mark.skip()
 def test_update_mappings(app):
     """Test if mapping gets correctly updated."""
 

--- a/tests/test_invenio_search.py
+++ b/tests/test_invenio_search.py
@@ -231,7 +231,8 @@ def test_creating_alias_existing_index(
         with pytest.raises(Exception):
             results = list(current_search.create(ignore=None))
         indices = current_search_client.indices.get("*", expand_wildcards="all")
-        index_names = list(indices.keys())
+        # filter out hidden indices like .plugins-ml-config
+        index_names = [i for i in index_names if not i.startswith(".")]
         assert index_names == new_indexes
         if create_index:
             assert len(indices[create_index]["aliases"]) == 0

--- a/tests/test_invenio_search.py
+++ b/tests/test_invenio_search.py
@@ -125,6 +125,7 @@ def test_load_entry_point_group(template_entrypoints):
     ):
         assert set(ext.templates.keys()) == {"record-view-{}".format(_get_version())}
 
+
 @pytest.mark.skip
 @pytest.mark.parametrize(
     ("aliases_config", "expected_aliases"),
@@ -171,6 +172,7 @@ def test_whitelisted_aliases(app, aliases_config, expected_aliases):
             assert current_search_client.indices.exists(all_expected)
 
     app.config["SEARCH_MAPPINGS"] = orig
+
 
 @pytest.mark.skip
 @pytest.mark.parametrize(
@@ -235,6 +237,7 @@ def test_creating_alias_existing_index(
         assert index_names == new_indexes
         if create_index:
             assert len(indices[create_index]["aliases"]) == 0
+
 
 @pytest.mark.skip
 @pytest.mark.parametrize(
@@ -306,17 +309,20 @@ def _test_prefix_indices(app, prefix_value):
     # clean-up
     current_search_client.indices.delete("*", expand_wildcards="all")
 
+
 @pytest.mark.skip
 def test_indices_prefix_empty_value(app):
     """Test indices creation with prefix value empty string."""
     prefix_value = ""
     _test_prefix_indices(app, prefix_value)
 
+
 @pytest.mark.skip
 def test_indices_prefix_none_value(app):
     """Test indices creation with a prefix value None."""
     prefix_value = None
     _test_prefix_indices(app, prefix_value)
+
 
 @pytest.mark.skip
 def test_indices_prefix_some_value(app):
@@ -363,17 +369,20 @@ def _test_prefix_templates(app, prefix_value, template_entrypoints):
         # clean-up
         current_search_client.indices.delete_template("*")
 
+
 @pytest.mark.skip
 def test_templates_prefix_empty_value(app, template_entrypoints):
     """Test templates creation with prefix value empty string."""
     prefix_value = ""
     _test_prefix_templates(app, prefix_value, template_entrypoints)
 
+
 @pytest.mark.skip
 def test_templates_prefix_none_value(app, template_entrypoints):
     """Test templates creation with a prefix value None."""
     prefix_value = None
     _test_prefix_templates(app, prefix_value, template_entrypoints)
+
 
 @pytest.mark.skip
 def test_templates_prefix_some_value(app, template_entrypoints):
@@ -399,6 +408,7 @@ def test_not_dry_run_and_index_exists(app):
     with pytest.raises(IndexAlreadyExistsError):
         list(search.create())
 
+
 @pytest.mark.skip()
 def test_create_selected_indexes(app):
     search = app.extensions["invenio-search"]
@@ -423,6 +433,7 @@ def test_create_selected_indexes(app):
     assert search.client.indices.exists("authors-authors-v1.0.0") is False
     assert search.client.indices.exists("records-authorities-authority-v1.0.0") is False
 
+
 @pytest.mark.skip()
 def test_delete_selected_indexes(app):
     search = app.extensions["invenio-search"]
@@ -438,6 +449,7 @@ def test_delete_selected_indexes(app):
         is True
     )
 
+
 @pytest.mark.skip()
 def test_create_when_indexes_already_exists_with_ignore_existing_true(app):
     search = app.extensions["invenio-search"]
@@ -450,6 +462,7 @@ def test_create_when_indexes_already_exists_with_ignore_existing_true(app):
         search.client.indices.exists("records-bibliographic-bibliographic-v1.0.0")
         is True
     )
+
 
 @pytest.mark.skip()
 def test_update_mappings(app):


### PR DESCRIPTION
Use importlib instead of os for registering schemas/templates

Not sure about _put_template(...), if it should be changed to importlib functions too. Function for opening file is located on row 473 in ext.py